### PR TITLE
Move the text to the bottom

### DIFF
--- a/src/main/resources/static/css/play.css
+++ b/src/main/resources/static/css/play.css
@@ -34,6 +34,8 @@ body {
 }
 
 #output-list {
+    position: absolute;
+    bottom: 10px;
     list-style: none;
     padding-left: 0;
     margin-top: 0;


### PR DESCRIPTION
When the screen is empty and the first text appears, have it appear at the bottom next to the input box. It's where you're going to spend most of your time looking once your screen fills up so it's weird to have to look at the top for a little while at the start. It also takes your eyes far away from the input bar which could be a usability problem.