### PR TITLE
Spring Boot style "autoconfiguration" for interpreter delegates

### DIFF
--- a/src/main/java/com/agonyengine/forge/config/InterpreterAutoConfiguration.java
+++ b/src/main/java/com/agonyengine/forge/config/InterpreterAutoConfiguration.java
@@ -1,0 +1,62 @@
+package com.agonyengine.forge.config;
+
+import com.agonyengine.forge.controller.interpret.DefaultInGameInterpreterDelegate;
+import com.agonyengine.forge.controller.interpret.DefaultLoginInterpreterDelegate;
+import com.agonyengine.forge.controller.interpret.InGameInterpreterDelegate;
+import com.agonyengine.forge.controller.interpret.LoginInterpreterDelegate;
+import com.agonyengine.forge.repository.ConnectionRepository;
+import com.agonyengine.forge.repository.CreatureRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.session.SessionRepository;
+
+import javax.inject.Inject;
+
+@Configuration
+public class InterpreterAutoConfiguration {
+    private LoginConfiguration loginConfiguration;
+    private UserDetailsManager userDetailsManager;
+    private AuthenticationManager authenticationManager;
+    private SessionRepository sessionRepository;
+    private ConnectionRepository connectionRepository;
+    private CreatureRepository creatureRepository;
+
+    @Inject
+    public InterpreterAutoConfiguration(
+        LoginConfiguration loginConfiguration,
+        @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") UserDetailsManager userDetailsManager,
+        AuthenticationManager authenticationManager,
+        SessionRepository sessionRepository,
+        ConnectionRepository connectionRepository,
+        CreatureRepository creatureRepository) {
+
+        this.loginConfiguration = loginConfiguration;
+        this.userDetailsManager = userDetailsManager;
+        this.authenticationManager = authenticationManager;
+        this.sessionRepository = sessionRepository;
+        this.connectionRepository = connectionRepository;
+        this.creatureRepository = creatureRepository;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(LoginInterpreterDelegate.class)
+    public LoginInterpreterDelegate loginInterpreterDelegate() {
+        return new DefaultLoginInterpreterDelegate(
+            loginConfiguration,
+            userDetailsManager,
+            authenticationManager,
+            sessionRepository,
+            connectionRepository,
+            creatureRepository
+        );
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(InGameInterpreterDelegate.class)
+    public InGameInterpreterDelegate inGameInterpreterDelegate() {
+        return new DefaultInGameInterpreterDelegate(creatureRepository, loginConfiguration);
+    }
+}

--- a/src/main/java/com/agonyengine/forge/controller/interpret/DefaultInGameInterpreterDelegate.java
+++ b/src/main/java/com/agonyengine/forge/controller/interpret/DefaultInGameInterpreterDelegate.java
@@ -6,16 +6,11 @@ import com.agonyengine.forge.controller.Output;
 import com.agonyengine.forge.model.Connection;
 import com.agonyengine.forge.model.Creature;
 import com.agonyengine.forge.repository.CreatureRepository;
-import org.springframework.stereotype.Component;
 
-import javax.inject.Inject;
-
-@Component
 public class DefaultInGameInterpreterDelegate extends BaseInterpreterDelegate implements InGameInterpreterDelegate {
     private CreatureRepository creatureRepository;
     private LoginConfiguration loginConfiguration; // TODO need to break this configuration apart
 
-    @Inject
     public DefaultInGameInterpreterDelegate(
         CreatureRepository creatureRepository,
         LoginConfiguration loginConfiguration) {

--- a/src/main/java/com/agonyengine/forge/controller/interpret/DefaultLoginInterpreterDelegate.java
+++ b/src/main/java/com/agonyengine/forge/controller/interpret/DefaultLoginInterpreterDelegate.java
@@ -23,9 +23,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
-import org.springframework.stereotype.Component;
 
-import javax.inject.Inject;
 import javax.transaction.Transactional;
 import java.util.Collections;
 
@@ -33,7 +31,6 @@ import static com.agonyengine.forge.model.DefaultLoginConnectionState.*;
 import static com.agonyengine.forge.model.PrimaryConnectionState.IN_GAME;
 import static org.springframework.security.web.context.HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY;
 
-@Component
 public class DefaultLoginInterpreterDelegate extends BaseInterpreterDelegate implements LoginInterpreterDelegate {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLoginInterpreterDelegate.class);
 
@@ -45,10 +42,9 @@ public class DefaultLoginInterpreterDelegate extends BaseInterpreterDelegate imp
     private ConnectionRepository connectionRepository;
     private CreatureRepository creatureRepository;
 
-    @Inject
     public DefaultLoginInterpreterDelegate(
         LoginConfiguration loginConfiguration,
-        @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") UserDetailsManager userDetailsManager,
+        UserDetailsManager userDetailsManager,
         AuthenticationManager authenticationManager,
         SessionRepository sessionRepository,
         ConnectionRepository connectionRepository,


### PR DESCRIPTION
If you provide your own implementation of these delegates, the default ones will now back off automatically and not be loaded into the Spring context.